### PR TITLE
[Improvement] Add line breaks for better display of Descriptions' multilines

### DIFF
--- a/pages/[multisigAddress]/[proposalId].tsx
+++ b/pages/[multisigAddress]/[proposalId].tsx
@@ -247,7 +247,7 @@ const Proposal: NextPage = () => {
           ) : (
             <div className="container mx-auto max-w-lg text-left">
               <h1 className="text-3xl font-bold mb-8">{proposal.title}</h1>
-              <p className="break-all mb-8">{proposal.description}</p>
+              <p className="whitespace-pre-line break-all mb-8">{proposal.description}</p>
               <div className="p-2 border border-black rounded mb-8">
                 <ReactCodeMirror
                   className="max-w-lg"


### PR DESCRIPTION
As title

**Before**
<img width="574" alt="image" src="https://github.com/user-attachments/assets/10f0944c-bebf-4771-919e-506b5bcaf2fc">


**After**
<img width="529" alt="image" src="https://github.com/user-attachments/assets/edb48e58-b07b-4bc4-903b-d62d53f22613">
